### PR TITLE
Add missing normal parameter in subplot function

### DIFF
--- a/meshplot/plot.py
+++ b/meshplot/plot.py
@@ -98,7 +98,7 @@ def plot(v, f=None, c=None, uv=None, n=None, shading={}, plot=None, return_plot=
     if return_plot or rendertype == "WEBSITE":
         return view
 
-def subplot(v, f=None, c=None, uv=None, shading={}, s=[1, 1, 0], data=None, texture_data=None):
+def subplot(v, f=None, c=None, uv=None, n=None, shading={}, s=[1, 1, 0], data=None, texture_data=None):
     shading["width"] = 400
     shading["height"] = 400
     view = Viewer(shading)


### PR DESCRIPTION
This PR fixes the subplot function which tried to use normals, although they were not declared as parameter.