### PR TITLE
Fix for linewidth > 1

### DIFF
--- a/meshplot/Viewer.py
+++ b/meshplot/Viewer.py
@@ -62,10 +62,11 @@ class Viewer():
         lines = lines.astype("float32", copy=False)
         mi = np.min(lines, axis=0)
         ma = np.max(lines, axis=0)
-        geometry = p3s.BufferGeometry(attributes={'position': p3s.BufferAttribute(lines, normalized=False)})
-        material = p3s.LineBasicMaterial(linewidth=shading["line_width"], color=shading["line_color"])
+        
+        geometry = p3s.LineSegmentsGeometry(positions=lines.reshape((-1, 2, 3)))
+        material = p3s.LineMaterial(linewidth=shading["line_width"], color=shading["line_color"])
                     #, vertexColors='VertexColors'),
-        lines = p3s.LineSegments(geometry=geometry, material=material) #type='LinePieces')
+        lines = p3s.LineSegments2(geometry=geometry, material=material) #type='LinePieces')
         line_obj = {"geometry": geometry, "mesh": lines, "material": material,
                     "max": ma, "min": mi, "type": "Lines", "wireframe": None}
 


### PR DESCRIPTION
## Why?
As [described here](https://pythreejs.readthedocs.io/en/stable/examples/ThickLines.html) line widths > 1 depend on OS/browser support to be displayed correctly. Currently on my system (Mac/Chrome) they will always display as line width 1 regardless of what number is used with `shading={"line_width": 5.0}`.

## What?
This PR adds a small fix to display line widths > 1 correctly.

<img width="683" alt="image" src="https://user-images.githubusercontent.com/619336/118347798-bb2c5300-b4fa-11eb-8aa9-b53a85e5ce98.png">

<img width="619" alt="image" src="https://user-images.githubusercontent.com/619336/118347879-368e0480-b4fb-11eb-9b64-5568fda63ac9.png">

<img width="507" alt="image" src="https://user-images.githubusercontent.com/619336/118347889-41489980-b4fb-11eb-9f80-fca4c7d7804b.png">



