### PR TITLE
Fix colors for tetrahedral mesh

### DIFF
--- a/meshplot/Viewer.py
+++ b/meshplot/Viewer.py
@@ -194,6 +194,9 @@ class Viewer():
                 f_tmp[i*4+3] = np.array([f[i][2], f[i][0], f[i][3]])
             f = f_tmp
 
+            if c is not None and len(c) == len(v):
+                c = np.repeat(c, 4, axis=0)
+
         if v.shape[1] == 2:
             v = np.append(v, np.zeros([v.shape[0], 1]), 1)
 


### PR DESCRIPTION
Hi,

Tetrahedral meshes are converted to triangle meshes internally. If a color array is specified with the same length as the number of tetrahedra, `meshplot` gives an error: `Invalid color array given! Supported are numpy arrays. <class 'numpy.ndarray'>`

This PR adds a fix that repeats the color array 4 times, so that the color array matches the number of triangles generated.