### PR TITLE
Correcting normalization

### DIFF
--- a/meshplot/Viewer.py
+++ b/meshplot/Viewer.py
@@ -131,18 +131,14 @@ class Viewer():
                 colors[:, 1] = 0.874
                 colors[:, 2] = 0.0
         elif type(c) == np.ndarray and c.size == f.shape[0]: # Function values for faces
-            normalize = sh["normalize"][0] == None or sh["normalize"][1] == None
-            cc = get_colors(c, sh["colormap"], normalize=normalize,
-                       vmin=sh["normalize"][0], vmax=sh["normalize"][1])
+            cc = get_colors(c, sh["colormap"], vmin=sh["normalize"][0], vmax=sh["normalize"][1])
             #print(cc.shape)
             colors = np.hstack([cc, cc, cc]).reshape((-1, 3))
             coloring = "FaceColors"
-            #print("Face function values")
+            print("Face function values")
         elif type(c) == np.ndarray and c.size == v.shape[0]: # Function values for vertices
-            normalize = sh["normalize"][0] == None or sh["normalize"][1] == None
-            colors = get_colors(c, sh["colormap"], normalize=normalize,
-                       vmin=sh["normalize"][0], vmax=sh["normalize"][1])
-            #print("Vertex function values")
+            colors = get_colors(c, sh["colormap"], vmin=sh["normalize"][0], vmax=sh["normalize"][1])
+            print("Vertex function values")
         else:
             colors = np.ones_like(v)
             colors[:, 0] = 1.0

--- a/meshplot/Viewer.py
+++ b/meshplot/Viewer.py
@@ -131,7 +131,7 @@ class Viewer():
                 colors[:, 1] = 0.874
                 colors[:, 2] = 0.0
         elif type(c) == np.ndarray and c.size == f.shape[0]: # Function values for faces
-            normalize = sh["normalize"][0] != None and sh["normalize"][1] != None
+            normalize = sh["normalize"][0] == None or sh["normalize"][1] == None
             cc = get_colors(c, sh["colormap"], normalize=normalize,
                        vmin=sh["normalize"][0], vmax=sh["normalize"][1])
             #print(cc.shape)
@@ -139,7 +139,7 @@ class Viewer():
             coloring = "FaceColors"
             #print("Face function values")
         elif type(c) == np.ndarray and c.size == v.shape[0]: # Function values for vertices
-            normalize = sh["normalize"][0] != None and sh["normalize"][1] != None
+            normalize = sh["normalize"][0] == None or sh["normalize"][1] == None
             colors = get_colors(c, sh["colormap"], normalize=normalize,
                        vmin=sh["normalize"][0], vmax=sh["normalize"][1])
             #print("Vertex function values")
@@ -167,7 +167,7 @@ class Viewer():
         elif type(c) == np.ndarray and len(c.shape) == 2 and c.shape[1] == 3 and c.shape[0] == v.shape[0]: # Point color
             colors = c.astype("float32", copy=False)
         elif type(c) == np.ndarray and c.size == v.shape[0]: # Function color
-            normalize = sh["normalize"][0] != None and sh["normalize"][1] != None
+            normalize = sh["normalize"][0] == None or sh["normalize"][1] == None
             colors = get_colors(c, sh["colormap"], normalize=normalize,
                        vmin=sh["normalize"][0], vmax=sh["normalize"][1])
             colors = colors.astype("float32", copy=False)

--- a/meshplot/Viewer.py
+++ b/meshplot/Viewer.py
@@ -163,9 +163,7 @@ class Viewer():
         elif type(c) == np.ndarray and len(c.shape) == 2 and c.shape[1] == 3 and c.shape[0] == v.shape[0]: # Point color
             colors = c.astype("float32", copy=False)
         elif type(c) == np.ndarray and c.size == v.shape[0]: # Function color
-            normalize = sh["normalize"][0] == None or sh["normalize"][1] == None
-            colors = get_colors(c, sh["colormap"], normalize=normalize,
-                       vmin=sh["normalize"][0], vmax=sh["normalize"][1])
+            colors = get_colors(c, sh["colormap"], vmin=sh["normalize"][0], vmax=sh["normalize"][1])
             colors = colors.astype("float32", copy=False)
             #print("Vertex function values")
         else:

--- a/meshplot/utils.py
+++ b/meshplot/utils.py
@@ -3,9 +3,9 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 
 # Helper functions
-def get_colors(inp, colormap="viridis", normalize=True, vmin=None, vmax=None):
+def get_colors(inp, colormap="viridis", vmin=None, vmax=None):
     colormap = plt.cm.get_cmap(colormap)
-    if normalize:
+    if vmin==None or vmax==None:
         vmin=np.min(inp)
         vmax=np.max(inp)
 


### PR DESCRIPTION
It was not possible to set vmin and vmax for normalization of the cmap.
With this changes, now it is possible to choose those values when setting shading = {"normalization": [vmin, vmax]}
inside plot or subplot.

The solution given in #41 works only for the case of choosing vmin and vmax, and would fail when the user wants 
vmin and vmax to be set automatically.